### PR TITLE
Fix for case where a TopicActor can continue sending messages to a member that no longer exists.

### DIFF
--- a/tests/Proto.Cluster.PubSub.Tests/PubSubClientTests.cs
+++ b/tests/Proto.Cluster.PubSub.Tests/PubSubClientTests.cs
@@ -1,0 +1,86 @@
+// -----------------------------------------------------------------------
+// <copyright file = "PubSubClientTests.cs" company = "Asynkron AB">
+//      Copyright (C) 2015-2024 Asynkron AB All rights reserved
+// </copyright>
+// -----------------------------------------------------------------------
+
+using FluentAssertions;
+using Xunit;
+using static Proto.Cluster.PubSub.Tests.WaitHelper;
+
+namespace Proto.Cluster.PubSub.Tests;
+
+[Collection("PubSub")] // The CI is just to slow to run cluster fixture based tests in parallel
+public class PubSubClientTests : IAsyncLifetime
+{
+	private readonly PubSubClusterFixture _fixture;
+
+	public PubSubClientTests()
+	{
+		_fixture = new PubSubClusterFixture();
+	}
+
+	public async Task InitializeAsync()
+	{
+		await _fixture.SpawnMember();
+		await _fixture.SpawnClient();
+	}
+
+	public Task DisposeAsync() => _fixture.DisposeAsync();
+
+	[Fact]
+	public async Task When_client_leaves_PID_subscribers_get_removed_due_to_dead_letter()
+	{
+		const string topic = "leaving-client";
+
+		// pid subscriber
+		var props = Props.FromFunc(ctx =>
+			{
+				if (ctx.Message is DataPublished msg)
+				{
+					_fixture.Deliveries.Add(new Delivery(ctx.Self.ToDiagnosticString(), msg.Data));
+				}
+
+				return Task.CompletedTask;
+			}
+		);
+
+		var client = _fixture.Clients.First();
+		var clientPid = client.System.Root.Spawn(props);
+		await client.Subscribe(topic, clientPid);
+        
+		var subscribers = await _fixture.GetSubscribersForTopic(topic);
+		subscribers.Subscribers_.Count.Should().Be(1);
+		subscribers.Subscribers_.Should().Contain(s => s.Pid.Equals(clientPid));
+        
+		// message should send
+		await _fixture.PublishData(topic, 1);
+        
+		await WaitUntil(() => _fixture.Deliveries.Count == 1);
+		_fixture.Deliveries.Count.Should().Be(1);
+		_fixture.Deliveries.Should().ContainSingle(d => d.Data == 1);
+
+		// shutdown client
+		await _fixture.RemoveNode(client, graceful: true);
+        
+		// subscription should remain, because it never unsubscribed, and there was no topology change
+		subscribers = await _fixture.GetSubscribersForTopic(topic);
+		subscribers.Subscribers_.Count.Should().Be(1);
+		subscribers.Subscribers_.Should().Contain(s => s.Pid.Equals(clientPid));
+        
+		// messages should not send or attempt to send
+		await _fixture.PublishData(topic, 2);
+		await Task.Delay(3000);
+		await _fixture.PublishData(topic, 2);
+	
+		// dead letter should be received, so the subscription is removed	
+		await WaitUntil(async () =>
+		{
+			subscribers = await _fixture.GetSubscribersForTopic(topic);
+			return subscribers.Subscribers_.Count == 0;
+		});
+		
+		_fixture.Deliveries.Count.Should().Be(1);
+		_fixture.Deliveries.Should().ContainSingle(d => d.Data == 1);
+	}
+}


### PR DESCRIPTION
## Description

<!-- If your pull request solves an issue, please reference it here -->
We had an issue where a client member would be shutdown, but a remaining member would keep trying to connect to it and failing forever. This was due to a subscription in the TopicActor to that removed member. Since it was a client member, it is not detected as a removal from the topology, which the TopicActor already watches to unsubscribe members that have shutdown but failed to unsubscribe. 

This change adds a handler for DeadLetterResponses to the TopicActor in order to detect when it is no longer able to reach a node with subscriptions, which then removes the subscriptions for that node. A test that validates the new code is included.

A minor change has been added to the BatchingProducer as well so it can stop more quickly and cleanly when it's being disposed.

## Purpose
This pull request is a:

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)


## Checklist

<!-- Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added necessary documentation (if appropriate)
